### PR TITLE
Introduce a DiffableTime typeclass

### DIFF
--- a/src/Data/Time/Distance.hs
+++ b/src/Data/Time/Distance.hs
@@ -1,6 +1,7 @@
 module Data.Time.Distance
     ( TimeUnit(..)
     , TimeDirection(..)
+    , DiffableTime(..)
     , distanceOfTime
     , distanceOfTimeInWords
     ) where
@@ -53,13 +54,19 @@ instance Show TimeDifference where
     show (TimeDifference distance direction) =
         show distance ++ " " ++ show direction
 
-distanceOfTimeInWords :: T.UTCTime -> T.UTCTime -> String
+class DiffableTime a where
+    toTime :: a -> T.UTCTime
+
+instance DiffableTime T.UTCTime where
+    toTime = id
+
+distanceOfTimeInWords :: (DiffableTime a, DiffableTime b) => a -> b -> String
 distanceOfTimeInWords a = show . distanceOfTime a
 
-distanceOfTime :: T.UTCTime -> T.UTCTime -> TimeDifference
+distanceOfTime :: (DiffableTime a, DiffableTime b) => a -> b -> TimeDifference
 distanceOfTime a b = TimeDifference (TimeDistance amount unit) (directionFromDiff diff)
   where
-    diff = T.diffUTCTime a b
+    diff = T.diffUTCTime (toTime a) (toTime b)
     (TimeDistance i unit) = M.fromMaybe years $ bestTimeDistance diff
     amount
         | c == 0 = abs $ floor $ diff * 1000

--- a/test/Data/Time/DistanceSpec.hs
+++ b/test/Data/Time/DistanceSpec.hs
@@ -24,36 +24,44 @@ spec =
     context "Data.Time.Distance" $ parallel $ modifyMaxSuccess (* 1000) $ do
         describe "distanceOfTimeInWords" $ do
             it "handles milliseconds" $ property $ \d -> do
-                distanceOfTimeInWords (addMilliseconds d (-30)) (toTime d) `shouldBe` "30 milliseconds ago"
-                distanceOfTimeInWords (addMilliseconds d (900)) (toTime d) `shouldBe` "900 milliseconds from now"
+                distanceOfTimeInWords (addMilliseconds d (-30)) (dayToTime d) `shouldBe` "30 milliseconds ago"
+                distanceOfTimeInWords (addMilliseconds d (900)) (dayToTime d) `shouldBe` "900 milliseconds from now"
 
             it "handles seconds" $ property $ \d -> do
-                distanceOfTimeInWords (addMilliseconds d (-30000)) (toTime d) `shouldBe` "30 seconds ago"
-                distanceOfTimeInWords (addMilliseconds d (45000)) (toTime d) `shouldBe` "45 seconds from now"
+                distanceOfTimeInWords (addMilliseconds d (-30000)) (dayToTime d) `shouldBe` "30 seconds ago"
+                distanceOfTimeInWords (addMilliseconds d (45000)) (dayToTime d) `shouldBe` "45 seconds from now"
 
             it "handles hours" $ property $ \d -> do
-                distanceOfTimeInWords (addHours d (-2)) (toTime d) `shouldBe` "2 hours ago"
-                distanceOfTimeInWords (addHours d 2) (toTime d) `shouldBe` "2 hours from now"
+                distanceOfTimeInWords (addHours d (-2)) (dayToTime d) `shouldBe` "2 hours ago"
+                distanceOfTimeInWords (addHours d 2) (dayToTime d) `shouldBe` "2 hours from now"
 
             it "handles days" $ property $ \d -> do
-                distanceOfTimeInWords (addDays d (-2)) (toTime d) `shouldBe` "2 days ago"
-                distanceOfTimeInWords (addDays d 2) (toTime d) `shouldBe` "2 days from now"
+                distanceOfTimeInWords (addDays d (-2)) (dayToTime d) `shouldBe` "2 days ago"
+                distanceOfTimeInWords (addDays d 2) (dayToTime d) `shouldBe` "2 days from now"
 
             it "handles weeks" $ property $ \d -> do
-                distanceOfTimeInWords (addDays d (-21)) (toTime d) `shouldBe` "3 weeks ago"
-                distanceOfTimeInWords (addDays d 21) (toTime d) `shouldBe` "3 weeks from now"
+                distanceOfTimeInWords (addDays d (-21)) (dayToTime d) `shouldBe` "3 weeks ago"
+                distanceOfTimeInWords (addDays d 21) (dayToTime d) `shouldBe` "3 weeks from now"
 
             it "handles months" $ property $ \d -> do
-                distanceOfTimeInWords (addDays d (-182)) (toTime d) `shouldBe` "6 months ago"
-                distanceOfTimeInWords (addDays d 40) (toTime d) `shouldBe` "1 month from now"
+                distanceOfTimeInWords (addDays d (-182)) (dayToTime d) `shouldBe` "6 months ago"
+                distanceOfTimeInWords (addDays d 40) (dayToTime d) `shouldBe` "1 month from now"
 
             it "handles years ago" $ property $ \d -> do
-                distanceOfTimeInWords (addDays d (-365)) (toTime d) `shouldBe` "12 months ago"
-                distanceOfTimeInWords (addDays d (-366)) (toTime d) `shouldBe` "2 years ago"
-                distanceOfTimeInWords (addDays d 365) (toTime d) `shouldBe` "12 months from now"
-                distanceOfTimeInWords (addDays d 400) (toTime d) `shouldBe` "1 year from now"
-                distanceOfTimeInWords (addDays d 710) (toTime d) `shouldBe` "1 year from now"
-                distanceOfTimeInWords (addDays d 730) (toTime d) `shouldBe` "2 years from now"
+                distanceOfTimeInWords (addDays d (-365)) (dayToTime d) `shouldBe` "12 months ago"
+                distanceOfTimeInWords (addDays d (-366)) (dayToTime d) `shouldBe` "2 years ago"
+                distanceOfTimeInWords (addDays d 365) (dayToTime d) `shouldBe` "12 months from now"
+                distanceOfTimeInWords (addDays d 400) (dayToTime d) `shouldBe` "1 year from now"
+                distanceOfTimeInWords (addDays d 710) (dayToTime d) `shouldBe` "1 year from now"
+                distanceOfTimeInWords (addDays d 730) (dayToTime d) `shouldBe` "2 years from now"
+
+            it "handles types for DiffableTime" $ property $ \d -> do
+                distanceOfTimeInWords (addDays d (-365)) d `shouldBe` "12 months ago"
+                distanceOfTimeInWords (addDays d (-366)) d `shouldBe` "2 years ago"
+                distanceOfTimeInWords (addDays d 365) d `shouldBe` "12 months from now"
+                distanceOfTimeInWords (addDays d 400) d `shouldBe` "1 year from now"
+                distanceOfTimeInWords (addDays d 710) d `shouldBe` "1 year from now"
+                distanceOfTimeInWords (addDays d 730) d `shouldBe` "2 years from now"
 
 addHours :: T.Day -> Integer -> T.UTCTime
 addHours d i = T.UTCTime d (fromInteger $ i * 60 * 60)
@@ -64,5 +72,8 @@ addMilliseconds d i = T.UTCTime d (fromRational $ i / 1000)
 addDays :: T.Day -> Integer -> T.UTCTime
 addDays d i = T.UTCTime (T.addDays i d) 0
 
-toTime :: T.Day -> T.UTCTime
-toTime d = T.UTCTime d (fromInteger 0)
+dayToTime :: T.Day -> T.UTCTime
+dayToTime = flip T.UTCTime 0
+
+instance DiffableTime T.Day where
+    toTime = dayToTime


### PR DESCRIPTION
Why?

This allows for authors to provide ways to compare types given `toTime`
instances are provided.

For example, one could then define an instance for Data.Time.Day:

```haskell
import qualified Data.Time as T

instance DiffableTime T.Day where
    toTime = flip T.UTCTime 0
```